### PR TITLE
bump prysmaticlabs/prysm to v1.1.0

### DIFF
--- a/beacon-chain/Dockerfile
+++ b/beacon-chain/Dockerfile
@@ -20,16 +20,12 @@ RUN apt update && \
 
 ADD ssl /ssl/
 
-# Verify binary is in correct arch
-RUN /usr/local/bin/beacon-chain --version
-
-ENTRYPOINT [ "sh", "-c", "echo \"0.0.0.0 beacon.prysm.dappnode\" >> /etc/hosts && \
-  exec beacon-chain \
+ENTRYPOINT [ "sh", "-c", "exec beacon-chain \
   --mainnet \
   --datadir=/data \
   --rpc-host=0.0.0.0 \
   --grpc-gateway-host=0.0.0.0 \
-  --monitoring-host=beacon-chain.prysm.dappnode \
+  --monitoring-host=0.0.0.0 \
   --http-web3provider=\"$HTTP_WEB3PROVIDER\" \
   --grpc-gateway-port=3500 \
   --grpc-gateway-corsdomain=\"$CORSDOMAIN\" \

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "prysm.dnp.dappnode.eth",
   "version": "1.0.0",
-  "upstreamVersion": "v1.0.2",
+  "upstreamVersion": "v1.1.0",
   "upstreamRepo": "prysmaticlabs/prysm",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Prysm mainnet ETH2.0 Beacon chain + validator",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: beacon-chain
       args:
-        UPSTREAM_VERSION: v1.0.5
+        UPSTREAM_VERSION: v1.1.0
     volumes:
       - "beacon-chain-data:/data"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     build:
       context: validator
       args:
-        UPSTREAM_VERSION: v1.0.5
+        UPSTREAM_VERSION: v1.1.0
     volumes:
       - "validator-data:/root/"
     restart: unless-stopped

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -22,13 +22,11 @@ COPY --from=binary /usr/local/bin/validator /usr/local/bin
 RUN /usr/local/bin/validator --version
 
 # Must used escaped \"$VAR\" to accept spaces: --graffiti=\"$GRAFFITI\"
-ENTRYPOINT [ "sh", "-c", "echo \"0.0.0.0 validator.prysm.dappnode\" >> /etc/hosts && \
-  exec validator \
+ENTRYPOINT [ "sh", "-c", "exec validator \
   --mainnet \
   --datadir=/root/.eth2 \
   --rpc-host 0.0.0.0 \
-  --grpc-gateway-host 0.0.0.0 \
-  --monitoring-host validator.prysm.dappnode \
+  --monitoring-host 0.0.0.0 \
   --beacon-rpc-provider=\"$BEACON_RPC_PROVIDER\" \
   --beacon-rpc-gateway-provider=\"$BEACON_RPC_GATEWAY_PROVIDER\" \
   --wallet-dir=/root/.eth2validators \


### PR DESCRIPTION
Bumps upstream version

- [prysmaticlabs/prysm](https://github.com/prysmaticlabs/prysm) from v1.0.5 to [v1.1.0](https://github.com/prysmaticlabs/prysm/releases/tag/v1.1.0)