### PR TITLE
bump prysmaticlabs/prysm to v1.2.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "prysm.dnp.dappnode.eth",
   "version": "1.0.0",
-  "upstreamVersion": "v1.1.0",
+  "upstreamVersion": "v1.2.2",
   "upstreamRepo": "prysmaticlabs/prysm",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Prysm mainnet ETH2.0 Beacon chain + validator",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: beacon-chain
       args:
-        UPSTREAM_VERSION: v1.1.0
+        UPSTREAM_VERSION: v1.2.2
     volumes:
       - "beacon-chain-data:/data"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     build:
       context: validator
       args:
-        UPSTREAM_VERSION: v1.1.0
+        UPSTREAM_VERSION: v1.2.2
     volumes:
       - "validator-data:/root/"
     restart: unless-stopped


### PR DESCRIPTION
Bumps upstream version

- [prysmaticlabs/prysm](https://github.com/prysmaticlabs/prysm) from v1.1.0 to [v1.2.2](https://github.com/prysmaticlabs/prysm/releases/tag/v1.2.2)