### PR TITLE
Set Max character Length For Graffiti String

### DIFF
--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -6,6 +6,7 @@ fields:
       name: GRAFFITI
       service: validator
     title: Graffiti
+    maxLength: 32
     description: >-
       Add a string to your proposed blocks, which will be seen on the block explorer
   - id: HTTP_WEB3PROVIDER


### PR DESCRIPTION
In response to https://github.com/dappnode/DAppNode/issues/363 This should limit the field in one of 2 spots where graffiti can be entered.  The other is in the config tab of the prysm application.  Should also be done for Prysm Prater fixes #47 