### PR TITLE
Prep for Merge

### DIFF
--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -14,11 +14,12 @@ fields:
       type: environment
       name: HTTP_WEB3PROVIDER
       service: beacon-chain
-    title: Eth1.x node URL
+    title: Execution Layer Node URL
     required: true
     description: >-
-      Your Beacon chain node must have access to a syncronized Eth1.x mainnet node. 
-      If you have not already, make sure to install and sync an Eth1.x node of your choice.
+      Your Beacon chain node must have access to a syncronized Execution Layer (EL) mainnet node.
+      To be ready for the Merge you must run your own EL client, and cannot rely on a remote service such as Infura.
+      If you have not already, make sure to install and sync an Execution Layer node of your choice.
       Then, input the URL of the node that you wish to use or a remote one:
 
       - Geth `http://geth.dappnode:8545` - [Install link](http://my.dappnode/#/installer/geth.dnp.dappnode.eth)


### PR DESCRIPTION
Prepping for merge by changing ETH1 => Execution Layer ( EL),
noting that for the upcoming merge Remote providers won't be an option.
fixes part of https://github.com/dappnode/DAppNode/issues/484