### PR TITLE
Add fee recipient check for EXTRA_OPTS

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -43,6 +43,12 @@ else
   FEE_RECIPIENT_ADDRESS="0x0000000000000000000000000000000000000000"
 fi
 
+# If EXTRA_OPTS does not include flag --suggested-fee-recipient, append it
+if [[ $EXTRA_OPTS != *"suggested-fee-recipient"* ]]; then
+  echo "Adding --suggested-fee-recipient=${FEE_RECIPIENT_ADDRESS} to EXTRA_OPTS"
+  EXTRA_OPTS="--suggested-fee-recipient=${FEE_RECIPIENT_ADDRESS} ${EXTRA_OPTS}"
+fi
+
 exec -c beacon-chain \
   --datadir=/data \
   --rpc-host=0.0.0.0 \


### PR DESCRIPTION
Fee recipient is checked to prevent failure if user has added fee recipient for beacon chain in EXTRA_OPTS